### PR TITLE
Reapply code cleanups on latest master

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,10 @@ jobs:
         # Allow files and folders starting with an underscore.
       - name: Add .nojekyll file
         run: touch ${{ env.PUBLISH_DIR }}/.nojekyll
-        
+
+      - name: Add CNAME file
+        run: Copy-Item 'Platforms\ZXBox.Blazor\wwwroot\CNAME' (Join-Path '${{ env.PUBLISH_DIR }}' 'CNAME')
+         
         # copy index.html to 404.html to serve the same file when a file is not found this makes deep linking possible
       - name: copy index.html to 404.html
         run: cp ${{ env.PUBLISH_DIR }}/index.html ${{ env.PUBLISH_DIR }}/404.html

--- a/Platforms/ZXBox.Blazor/ZXBox.Blazor.csproj
+++ b/Platforms/ZXBox.Blazor/ZXBox.Blazor.csproj
@@ -30,6 +30,10 @@
     <Content Update="wwwroot\css\zx.ttf">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Update="wwwroot\CNAME">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
     <Content Update="wwwroot\images\48.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/Platforms/ZXBox.Blazor/wwwroot/CNAME
+++ b/Platforms/ZXBox.Blazor/wwwroot/CNAME
@@ -1,0 +1,1 @@
+zxbox.com


### PR DESCRIPTION
## Summary
- reapply the code-cleanup and API-signature work on top of current master across the core emulator and Meadow code
- keep the .NET 10 Blazor and MonoGame projects aligned, include the Currah ROM assets, and preserve the Currah opcode-fetch path after the rebase
- fix the Blazor Toolbelt Gamepad startup/runtime issues and preserve the GitHub Pages custom domain with a published CNAME file

## Validation
- dotnet test ZXBox.Core.Tests\ZXBox.Core.Tests.csproj --filter "FullyQualifiedName~UnitTests|FullyQualifiedName~CoreTest" -v minimal -p:UseSharedCompilation=false
- dotnet build Platforms\ZXBox.Monogame\ZXBox.Monogame.csproj -v minimal -p:UseSharedCompilation=false
- dotnet publish Platforms\ZXBox.Blazor\ZXBox.Blazor.csproj -c Release -v minimal -p:UseSharedCompilation=false